### PR TITLE
Compare dimension object instead of dimension name

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -104,7 +104,7 @@ export default ['$scope', '$element', function ($scope, $element) {
     });
   }
 
-  $scope.$watch("layout.qHyperCube.qDimensionInfo[0].qGroupFieldDefs[0]", async function (newValue, oldValue) {
+  $scope.$watch("layout.qHyperCube.qDimensionInfo[0]", async function (newValue, oldValue) {
     if (!$scope.layout.prop.vizId) {
       helper.getMasterItems().then(function(items) {
         $scope.masterVizs = items;


### PR DESCRIPTION
Currently the visualization doesn't edit if a new value is added to the dimension or the order of the dimensions changes, by comparing the object instead of just the title we can catch any change made to the dimension and refresh the visualization.