### PR TITLE
Small change (5 lines of code changed) to controller.js

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -23,7 +23,7 @@ export default ['$scope', '$element', function ($scope, $element) {
     }
   });
 
-  $scope.$watch("layout.qHyperCube.qDimensionInfo", function (newValue, oldValue) {
+  $scope.watchCollection("layout.qHyperCube.qDimensionInfo", function (newValue, oldValue) {
     if (newValue !== oldValue) {
       setupStyles().then(function () {
         createTrellisObjects();
@@ -397,7 +397,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({1}1)`
+              "qDef": `Sum({$}1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,
@@ -435,7 +435,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({1}1)`
+              "qDef": `Sum({$}1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,
@@ -461,7 +461,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({1}1)`
+              "qDef": `Sum({$}1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,
@@ -749,7 +749,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }
         }
         if ($scope.layout.prop.showAllDims && showAll) {
-          currentMes += " + 0*Sum({1}1)";
+          currentMes += " + 0*Sum({$}1)";
         }
         if (typeof dimName2 != 'undefined') {
           currentMes = currentMes.replaceAll('$(vDimSetFull)', `{<[${dimName}]={'${dimValue}'}, [${dimName2}]={'${dimValue2}'}>}`);

--- a/src/controller.js
+++ b/src/controller.js
@@ -23,7 +23,7 @@ export default ['$scope', '$element', function ($scope, $element) {
     }
   });
 
-  $scope.watchCollection("layout.qHyperCube.qDimensionInfo", function (newValue, oldValue) {
+  $scope.$watchCollection("layout.qHyperCube.qDimensionInfo", function (newValue, oldValue) {
     if (newValue !== oldValue) {
       setupStyles().then(function () {
         createTrellisObjects();
@@ -255,7 +255,21 @@ export default ['$scope', '$element', function ($scope, $element) {
       createTrellisObjects();
     }
   });
-
+  
+  $scope.$watch("layout.prop.reactToTrellisDimSel", function (newValue, oldValue) {
+    if (newValue !== oldValue) {
+      try {
+        setupStyles().then(function () {
+          createTrellisObjects();
+        });
+      }
+      catch (err) {
+        // Destroy existing session objects
+        destroyTrellisObjects();
+      }
+    }
+  });
+  
   $scope.$watch("layout.prop.label", function (newValue, oldValue) {
     if (newValue !== oldValue) {
       createTrellisObjects();
@@ -394,17 +408,17 @@ export default ['$scope', '$element', function ($scope, $element) {
               "qSortCriterias": $scope.sortCriterias1
             },
             "qNullSuppression": $scope.nullSuppression1
-          }],
-          "qMeasures": [{
+	  }],
+	  "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({$}1)`
+              "qDef": ($scope.layout.prop.reactToTrellisDimSel) ? `Sum({$}1)` : `Sum({1}1)`
             }
-          }],
-          "qSortCriterias": $scope.sortCriterias,
-          "qInitialDataFetch": [{
+	  }],
+	  "qSortCriterias": $scope.sortCriterias,
+	  "qInitialDataFetch": [{
             qHeight: 500,
             qWidth: 2
-          }]
+	  }]
         };
         let reply = await app.createCube(params);
         console.log(reply);
@@ -435,7 +449,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({$}1)`
+              "qDef": ($scope.layout.prop.reactToTrellisDimSel) ? `Sum({$}1)` : `Sum({1}1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,
@@ -461,7 +475,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({$}1)`
+              "qDef": ($scope.layout.prop.reactToTrellisDimSel) ? `Sum({$}1)` : `Sum({1}1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,
@@ -749,7 +763,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }
         }
         if ($scope.layout.prop.showAllDims && showAll) {
-          currentMes += " + 0*Sum({$}1)";
+          currentMes += " + 0*Sum({1}1)";
         }
         if (typeof dimName2 != 'undefined') {
           currentMes = currentMes.replaceAll('$(vDimSetFull)', `{<[${dimName}]={'${dimValue}'}, [${dimName2}]={'${dimValue2}'}>}`);

--- a/src/definition.js
+++ b/src/definition.js
@@ -268,7 +268,26 @@ define(['./helper'], function (helper) {
     ],
     defaultValue: true
   };
-
+  
+  //e.preuss@consus-clinicmanagement.de: switch to turn on associative mode, in which the trellis container
+  //will react to direct selections and other changes of the set of the trellis dimension's
+  //possible values.
+  var reactToTrellisDimSelections = {
+    ref: "prop.reactToTrellisDimSel",
+    label: "Associative mode",
+    component: 'switch',
+    type: "boolean",
+    options: [{
+      value: false,
+      label: "Off"
+    }, {
+      value: true,
+      label: "On"
+    }
+    ],
+    defaultValue: false
+  };
+  
   var customTitle = {
     ref: "prop.customTitle",
     label: "Custom Title",
@@ -406,6 +425,7 @@ define(['./helper'], function (helper) {
           customTitleRowDef: customTitleRowDef,
           customValuesRowDef: customValuesRowDef,
           showAllDimensionValues: showAllDimensionValues,
+          reactToTrellisDimSelections: reactToTrellisDimSelections,
           border: border,
           borderWidth: borderWidth,
           borderColor: borderColor,


### PR DESCRIPTION
Hello QlikTechs,
I did this change, because the trellis container - imo - did not quite behave like a properly integrated Qlik Sense Extension should do. Above all, I was surprised to see, that there was no immediate reaction to any selections made in the hypercube. And secondly, instead of always rendering the master visualization for all trellis dimension values (eventually resulting in several charts saying "no data to display"), I only want it to paint the master visualization for the possible trellis dimension values.
So that's what this tiny change does. 
This change results in the controller.js instantaneously reacting to selections and skipping the rendering for the trellis-dimension's non-possible values.

Hope You like it. ;-)

With kind regards
Eric