### PR TITLE
Trellis chart should update when a user does a selection

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -14,6 +14,26 @@ export default ['$scope', '$element', function ($scope, $element) {
   $scope.layout.getScope = function () {
     return $scope;
   };
+  
+  // create Trellis when the number of selected values in listbox change
+  $scope.$watch("layout.qHyperCube.qDimensionInfo[0].qStateCounts.qSelected", function (newValue, oldValue) {
+    if (newValue !== oldValue) {
+      setupStyles().then(function () {
+        createTrellisObjects();
+      });
+    }
+  });
+  
+  // create Trellis when the value of the first selected Value in the listbox changes (in case user has changed from one value to another value)
+  $scope.$watch("layout.qHyperCube.qDataPages[0].qMatrix[0][0].qText", function (newValue, oldValue) {
+    if (newValue !== oldValue) {
+      setupStyles().then(function () {
+        createTrellisObjects();
+      });
+    }
+  });
+  
+  
 
   $scope.$watch("layout.prop.columns", function (newValue, oldValue) {
     if (newValue !== oldValue) {
@@ -397,7 +417,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({1}1)`
+              "qDef": `Sum(1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,
@@ -435,7 +455,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({1}1)`
+              "qDef": `Sum(1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,
@@ -461,7 +481,7 @@ export default ['$scope', '$element', function ($scope, $element) {
           }],
           "qMeasures": [{
             "qDef": {
-              "qDef": `Sum({1}1)`
+              "qDef": `Sum(1)`
             }
           }],
           "qSortCriterias": $scope.sortCriterias,


### PR DESCRIPTION
Today I learned that the Trellis Container from the Qlik Sense Visualization Bundle does not react to user selections when it's dimension is selected. This is very strange because every other Qlik Sense Object is able to do so. This is even listed as limitation on https://help.qlik.com/en-US/sense/November2020/Subsystems/Hub/Content/Sense_Hub/Visualizations/VisualizationBundle/trellis-container.htm


I looked at the code, and realized that the extension simply does not react to any changes in the user selection state. This means the Object is not rerendered when a selection is done on the Trellis dimension.


I just added a 2 "watch" functions and removed the strange SET ANALYSIS {1} selection from the Hypercube Definition, which could be another reason why always all dimensions are shown. 

I guess there is a smarter solution than that, but this would be a huge improvment to the trellis object. See how beautiful the extension now works: http://content.heldendaten.eu/fix_trellis_Extension.gif



Roland