### PR TITLE
fix: add sn-analysis-autochart to forbidden visualizations for Trellis container

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -7,6 +7,8 @@ define(["qlik"], function (qlik) {
       'qlik-trellis-container',
       'filterpane',
       'histogram',
+      'sn-layout-container',
+      'sn-tabbed-container',
       'sn-analysis-autochart'],
 
     getFields: function () {

--- a/src/helper.js
+++ b/src/helper.js
@@ -6,7 +6,8 @@ define(["qlik"], function (qlik) {
       'qlik-tabbed-container',
       'qlik-trellis-container',
       'filterpane',
-      'histogram'],
+      'histogram',
+      'sn-analysis-autochart'],
 
     getFields: function () {
       var app = qlik.currApp(this);


### PR DESCRIPTION
Fixes [QB-26775 - Analysis chart misbehaves in Trellis container](https://jira.qlikdev.com/browse/QB-26775)


Add sn-analysis-autochart to forbidden visualizations for Trellis container.